### PR TITLE
LAN mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,6 @@ volumes:
 The default configuration will use the x64 tutk library, however, you can edit your `docker-compose.yml` to use the 32-bit arm library by setting `dockerfile` as `Dockerfile.arm`:
 
 ```YAML
-..
     build: 
         context: ./app
         dockerfile: Dockerfile.arm
@@ -138,7 +137,6 @@ The default configuration will use the x64 tutk library, however, you can edit y
 
 Alternatively, you can pull a pre-built image using:
 ```yaml
-..
     image: mrlt8/wyze-bridge:latest
     environment:
         ..
@@ -152,7 +150,6 @@ LAN mode is more ideal as all streaming will be local and won't use additional b
 
 You can restrict streaming to LAN only by adding the `LAN_ONLY` environment variable:
 ```yaml
-...
 environment:
 	..
     - LAN_ONLY=True

--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ Should work on most x64 systems as well as on some arm-based systems like the Ra
 
 ## Changes in v0.5.0
 
-**Upgrading from v0.3.x to v0.4.0+ may require a new docker-compose.yml**
-
 - Improved LAN mode. No longer requires host mode.
 
 
@@ -25,8 +23,9 @@ docker run -p 1935:1935 -p 8554:8554 -p 8888:8888 -e WYZE_EMAIL= -e WYZE_PASSWOR
 ```
 
 ##### Build with docker-compose (recommended)
-1. git clone this repo or download the latest [release](https://github.com/mrlt8/docker-wyze-bridge/releases)
-1. Copy and rename the sample yml to `docker-compose.yml` 
+1. `git clone https://github.com/mrlt8/docker-wyze-bridge.git`
+1. `cd docker-wyze-bridge`
+1. `cp docker-compose.sample.yml docker-compose.yml` 
 1. Edit `docker-compose.yml` with your wyze credentials
 1. run `docker-composer up`
 

--- a/README.md
+++ b/README.md
@@ -4,33 +4,34 @@ Docker container to expose a local RTMP, RTSP, and HLS stream for all your Wyze 
 
 Based on [@noelhibbard's script](https://gist.github.com/noelhibbard/03703f551298c6460f2fd0bfdbc328bd#file-readme-md) with [kroo/wyzecam](https://github.com/kroo/wyzecam), [aler9/rtsp-simple-server](https://github.com/aler9/rtsp-simple-server), and [shauntarves/wyze-sdk](https://github.com/shauntarves/wyze-sdk).
 
-##### Compatibility:
+### Compatibility:
 Should work on most x64 systems as well as on some arm-based systems like the Raspberry Pi.
 
 [See here](#armraspberry-pi-support) for instructions to run on arm.
 
 ## Changes in v0.5.0
 
-- FIX: MFA error due to (missing user-agent)[https://github.com/shauntarves/wyze-sdk/issues/35#issuecomment-885325398]
+- FIX: MFA error due to [missing user-agent](https://github.com/shauntarves/wyze-sdk/issues/35#issuecomment-885325398)
 - Improved LAN mode - no longer requires host mode
 - Improved stability
 
 ## Usage
 
-##### docker run
+### docker run
 Use your Wyze credentials and run:
 ```
 docker run -p 1935:1935 -p 8554:8554 -p 8888:8888 -e WYZE_EMAIL= -e WYZE_PASSWORD=  mrlt8/wyze-bridge
 ```
+or
 
-##### Build with docker-compose (recommended)
+### Build with docker-compose (recommended)
 1. `git clone https://github.com/mrlt8/docker-wyze-bridge.git`
 1. `cd docker-wyze-bridge`
 1. `cp docker-compose.sample.yml docker-compose.yml` 
 1. Edit `docker-compose.yml` with your wyze credentials
-1. run `docker-composer up`
+1. run `docker-composer up --build`
 
-##### Additional Info
+### Additional Info
 - [Two-Step Verification](#Multi-Factor-Authentication)
 - [ARM/Raspberry Pi](#armraspberry-pi-support)
 - [LAN mode](#LAN-Mode)

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ Should work on most x64 systems as well as on some arm-based systems like the Ra
 
 ## Changes in v0.5.0
 
-- Improved LAN mode. No longer requires host mode.
-
+- FIX: MFA error due to (missing user-agent)[https://github.com/shauntarves/wyze-sdk/issues/35#issuecomment-885325398]
+- Improved LAN mode - no longer requires host mode
+- Improved stability
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -5,27 +5,21 @@ Docker container to expose a local RTMP, RTSP, and HLS stream for all your Wyze 
 Based on [@noelhibbard's script](https://gist.github.com/noelhibbard/03703f551298c6460f2fd0bfdbc328bd#file-readme-md) with [kroo/wyzecam](https://github.com/kroo/wyzecam), [aler9/rtsp-simple-server](https://github.com/aler9/rtsp-simple-server), and [shauntarves/wyze-sdk](https://github.com/shauntarves/wyze-sdk).
 
 ##### Compatibility:
-Should work on most x64 systems as well as on some arm-based systems like the Raspberry Pi, however, ["LAN mode"](#LAN-Mode) requires a linux-based system due to host mode compatibility.
+Should work on most x64 systems as well as on some arm-based systems like the Raspberry Pi.
 
 [See here](#armraspberry-pi-support) for instructions to run on arm.
 
-## Changes in v0.4.3
+## Changes in v0.5.0
 
 **Upgrading from v0.3.x to v0.4.0+ may require a new docker-compose.yml**
 
-- FIX: 'type' error due to missing codec info - Thanks to @jmacul2
-- Switch to threading for performance bump
-- Increase retry time for offline cameras
+- Improved LAN mode. No longer requires host mode.
 
 
 ## Usage
 
 ##### docker run
-If on a linux based system, use your Wyze credentials and run:
-```
-docker run --network host -e WYZE_EMAIL= -e WYZE_PASSWORD=  mrlt8/wyze-bridge
-```
-or if on a non-linux system that doesn't support host mode:
+Use your Wyze credentials and run:
 ```
 docker run -p 1935:1935 -p 8554:8554 -p 8888:8888 -e WYZE_EMAIL= -e WYZE_PASSWORD=  mrlt8/wyze-bridge
 ```
@@ -133,30 +127,20 @@ volumes:
 The default configuration will use the x64 tutk library, however, you can edit your `docker-compose.yml` to use the 32-bit arm library by setting `dockerfile` as `Dockerfile.arm`:
 
 ```YAML
-version: '3.8'
-services:
-    wyze-bridge:
-        restart: always
-        network_mode: host
-        build: 
-            context: ./app
-            dockerfile: Dockerfile.arm
-        environment:
-            - WYZE_EMAIL=
-            - WYZE_PASSWORD=
+..
+    build: 
+        context: ./app
+        dockerfile: Dockerfile.arm
+    environment:
+        ..
 ```
 
 Alternatively, you can pull a pre-built image using:
 ```yaml
-version: '3.8'
-services:
-    wyze-bridge:
-        restart: always
-        network_mode: host
-        image: mrlt8/wyze-bridge:latest
-        environment:
-            - WYZE_EMAIL=
-            - WYZE_PASSWORD=
+..
+    image: mrlt8/wyze-bridge:latest
+    environment:
+        ..
 ```
 
 ## LAN Mode
@@ -165,18 +149,7 @@ Like the wyze app, the tutk library will attempt to stream directly from the cam
 
 LAN mode is more ideal as all streaming will be local and won't use additional bandwidth.
 
-To enable LAN mode, you'll need to be on a linux-based system and modify your docker-compose.yml to enable host network_mode and remove the ports:
-```yaml
-...
-services:
-    wyze-bridge:
-        restart: always
-        network_mode: host
-        build: 
-        ...
-```
-
-You can further restrict streaming to LAN only by adding the `LAN_ONLY` environment variable:
+You can restrict streaming to LAN only by adding the `LAN_ONLY` environment variable:
 ```yaml
 ...
 environment:

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update &&\
 ADD https://github.com/mrlt8/wyzecam/archive/refs/heads/patch-1.zip /tmp/wyzecam.zip
 RUN unzip /tmp/wyzecam.zip -d /tmp/ &&\
     cd /tmp/wyzecam-patch-1 &&\
-    pip3 install --no-warn-script-location --prefix=/build . requests wyze_sdk supervisor
+    pip3 install --no-warn-script-location --prefix=/build . requests wyze_sdk supervisor &&\
+    sed -i '/x-api-key/a \            '\''user-agent'\''\: '\''wyze_ios_2.22.32'\'',' /build/lib/python3.9/site-packages/wyze_sdk/service/auth_service.py
 # TEMP Patch END
 
 ADD https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-${FFMPEG_ARCH:-amd64}-static.tar.xz /tmp/ffmpeg.tar.xz

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -11,13 +11,21 @@ RUN apt-get update &&\
     apt-get install -y tar xz-utils unzip g++ &&\
     apt-get clean &&\
     rm -rf /var/lib/apt/lists/*
-RUN pip3 install --no-warn-script-location --prefix=/build requests wyzecam wyze_sdk supervisor
+
+# TEMP Patch START
+# RUN pip3 install --no-warn-script-location --prefix=/build requests wyzecam wyze_sdk supervisor
+ADD https://github.com/mrlt8/wyzecam/archive/refs/heads/patch-1.zip /tmp/wyzecam.zip
+RUN unzip /tmp/wyzecam.zip -d /tmp/ &&\
+    cd /tmp/wyzecam-patch-1 &&\
+    pip3 install --no-warn-script-location --prefix=/build . requests wyze_sdk supervisor
+# TEMP Patch END
+
 ADD https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-${FFMPEG_ARCH:-amd64}-static.tar.xz /tmp/ffmpeg.tar.xz
-ADD https://github.com/nblavoie/wyzecam-api/raw/master/wyzecam-sdk/TUTK_IOTC_Platform_14W42P1.zip /tmp/tutk.zip
+ADD https://github.com/miguelangel-nubla/videoP2Proxy/archive/refs/heads/master.zip /tmp/tutk.zip
 ADD https://github.com/aler9/rtsp-simple-server/releases/download/v0.16.4/rtsp-simple-server_v0.16.4_linux_${RTSP_ARCH:-amd64}.tar.gz /tmp/rtsp.tar.gz
 RUN mkdir -p /app &&\
-    unzip /tmp/tutk.zip Lib/Linux/${TUTK_ARCH:-x64}/*.a -d /tmp/tutk/ &&\
-    cd /tmp/tutk/Lib/Linux/${TUTK_ARCH:-x64}/ &&\
+    unzip -j /tmp/tutk.zip */lib/Linux/${TUTK_ARCH:-x64}/*.a -d /tmp/tutk/ &&\
+    cd /tmp/tutk &&\
     g++ -fpic -shared -Wl,--whole-archive libAVAPIs.a libIOTCAPIs.a -Wl,--no-whole-archive -o /build/lib/libIOTCAPIs_ALL.so &&\
     tar -xzf /tmp/rtsp.tar.gz -C /app &&\
     tar --strip-components=1 -C /build/bin -xf /tmp/ffmpeg.tar.xz --wildcards '*ffmpeg' &&\
@@ -26,7 +34,7 @@ RUN mkdir -p /app &&\
 FROM base
 ENV PYTHONUNBUFFERED=1
 COPY --from=builder /build /usr/local
-COPY --from=builder /app/* /app/
+COPY --from=builder /app /app
 RUN mkdir -p /tokens 
 COPY wyze_bridge.py supervisord.conf /app/
 CMD ["supervisord", "-c", "/app/supervisord.conf" ]

--- a/app/Dockerfile.arm
+++ b/app/Dockerfile.arm
@@ -17,7 +17,8 @@ RUN apt-get update &&\
 ADD https://github.com/mrlt8/wyzecam/archive/refs/heads/patch-1.zip /tmp/wyzecam.zip
 RUN unzip /tmp/wyzecam.zip -d /tmp/ &&\
     cd /tmp/wyzecam-patch-1 &&\
-    pip3 install --no-warn-script-location --prefix=/build . requests wyze_sdk supervisor
+    pip3 install --no-warn-script-location --prefix=/build . requests wyze_sdk supervisor &&\
+    sed -i '/x-api-key/a \            '\''user-agent'\''\: '\''wyze_ios_2.22.32'\'',' /build/lib/python3.9/site-packages/wyze_sdk/service/auth_service.py
 # TEMP Patch END
 
 ADD https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-${FFMPEG_ARCH:-amd64}-static.tar.xz /tmp/ffmpeg.tar.xz

--- a/app/Dockerfile.arm
+++ b/app/Dockerfile.arm
@@ -11,13 +11,21 @@ RUN apt-get update &&\
     apt-get install -y tar xz-utils unzip g++ &&\
     apt-get clean &&\
     rm -rf /var/lib/apt/lists/*
-RUN pip3 install --no-warn-script-location --prefix=/build requests wyzecam wyze_sdk supervisor
+
+# TEMP Patch START
+# RUN pip3 install --no-warn-script-location --prefix=/build requests wyzecam wyze_sdk supervisor
+ADD https://github.com/mrlt8/wyzecam/archive/refs/heads/patch-1.zip /tmp/wyzecam.zip
+RUN unzip /tmp/wyzecam.zip -d /tmp/ &&\
+    cd /tmp/wyzecam-patch-1 &&\
+    pip3 install --no-warn-script-location --prefix=/build . requests wyze_sdk supervisor
+# TEMP Patch END
+
 ADD https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-${FFMPEG_ARCH:-amd64}-static.tar.xz /tmp/ffmpeg.tar.xz
-ADD https://github.com/nblavoie/wyzecam-api/raw/master/wyzecam-sdk/TUTK_IOTC_Platform_14W42P1.zip /tmp/tutk.zip
+ADD https://github.com/miguelangel-nubla/videoP2Proxy/archive/refs/heads/master.zip /tmp/tutk.zip
 ADD https://github.com/aler9/rtsp-simple-server/releases/download/v0.16.4/rtsp-simple-server_v0.16.4_linux_${RTSP_ARCH:-amd64}.tar.gz /tmp/rtsp.tar.gz
 RUN mkdir -p /app &&\
-    unzip /tmp/tutk.zip Lib/Linux/${TUTK_ARCH:-x64}/*.a -d /tmp/tutk/ &&\
-    cd /tmp/tutk/Lib/Linux/${TUTK_ARCH:-x64}/ &&\
+    unzip -j /tmp/tutk.zip */lib/Linux/${TUTK_ARCH:-x64}/*.a -d /tmp/tutk/ &&\
+    cd /tmp/tutk &&\
     g++ -fpic -shared -Wl,--whole-archive libAVAPIs.a libIOTCAPIs.a -Wl,--no-whole-archive -o /build/lib/libIOTCAPIs_ALL.so &&\
     tar -xzf /tmp/rtsp.tar.gz -C /app &&\
     tar --strip-components=1 -C /build/bin -xf /tmp/ffmpeg.tar.xz --wildcards '*ffmpeg' &&\
@@ -26,7 +34,7 @@ RUN mkdir -p /app &&\
 FROM base
 ENV PYTHONUNBUFFERED=1
 COPY --from=builder /build /usr/local
-COPY --from=builder /app/* /app/
+COPY --from=builder /app /app
 RUN mkdir -p /tokens 
 COPY wyze_bridge.py supervisord.conf /app/
 CMD ["supervisord", "-c", "/app/supervisord.conf" ]

--- a/app/multi-arch.Dockerfile
+++ b/app/multi-arch.Dockerfile
@@ -19,11 +19,11 @@ RUN apt-get update &&\
     rm -rf /var/lib/apt/lists/*
 RUN pip3 install --no-warn-script-location --prefix=/build requests wyzecam wyze_sdk supervisor
 ADD https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-${FFMPEG_ARCH:-amd64}-static.tar.xz /tmp/ffmpeg.tar.xz
-ADD https://github.com/nblavoie/wyzecam-api/raw/master/wyzecam-sdk/TUTK_IOTC_Platform_14W42P1.zip /tmp/tutk.zip
+ADD https://github.com/miguelangel-nubla/videoP2Proxy/archive/refs/heads/master.zip /tmp/tutk.zip
 ADD https://github.com/aler9/rtsp-simple-server/releases/download/v0.16.4/rtsp-simple-server_v0.16.4_linux_${RTSP_ARCH:-amd64}.tar.gz /tmp/rtsp.tar.gz
 RUN mkdir -p /app &&\
-    unzip /tmp/tutk.zip Lib/Linux/${TUTK_ARCH:-x64}/*.a -d /tmp/tutk/ &&\
-    cd /tmp/tutk/Lib/Linux/${TUTK_ARCH:-x64}/ &&\
+    unzip -j /tmp/tutk.zip */lib/Linux/${TUTK_ARCH:-x64}/*.a -d /tmp/tutk/ &&\
+    cd /tmp/tutk &&\
     g++ -fpic -shared -Wl,--whole-archive libAVAPIs.a libIOTCAPIs.a -Wl,--no-whole-archive -o /build/lib/libIOTCAPIs_ALL.so &&\
     tar -xzf /tmp/rtsp.tar.gz -C /app &&\
     tar --strip-components=1 -C /build/bin -xf /tmp/ffmpeg.tar.xz --wildcards '*ffmpeg' &&\

--- a/app/multi-arch.Dockerfile
+++ b/app/multi-arch.Dockerfile
@@ -17,7 +17,16 @@ RUN apt-get update &&\
     apt-get install -y tar xz-utils unzip g++ &&\
     apt-get clean &&\
     rm -rf /var/lib/apt/lists/*
-RUN pip3 install --no-warn-script-location --prefix=/build requests wyzecam wyze_sdk supervisor
+
+# TEMP Patch START
+# RUN pip3 install --no-warn-script-location --prefix=/build requests wyzecam wyze_sdk supervisor
+ADD https://github.com/mrlt8/wyzecam/archive/refs/heads/patch-1.zip /tmp/wyzecam.zip
+RUN unzip /tmp/wyzecam.zip -d /tmp/ &&\
+    cd /tmp/wyzecam-patch-1 &&\
+    pip3 install --no-warn-script-location --prefix=/build . requests wyze_sdk supervisor &&\
+    sed -i '/x-api-key/a \            '\''user-agent'\''\: '\''wyze_ios_2.22.32'\'',' /build/lib/python3.9/site-packages/wyze_sdk/service/auth_service.py
+# TEMP Patch END
+
 ADD https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-${FFMPEG_ARCH:-amd64}-static.tar.xz /tmp/ffmpeg.tar.xz
 ADD https://github.com/miguelangel-nubla/videoP2Proxy/archive/refs/heads/master.zip /tmp/tutk.zip
 ADD https://github.com/aler9/rtsp-simple-server/releases/download/v0.16.4/rtsp-simple-server_v0.16.4_linux_${RTSP_ARCH:-amd64}.tar.gz /tmp/rtsp.tar.gz

--- a/app/wyze_bridge.py
+++ b/app/wyze_bridge.py
@@ -126,7 +126,7 @@ class wyze_bridge:
 						'-i', '-',
 						'-map','0:v:0',
 						'-vcodec', 'copy',
-						# '-rtsp_transport','udp',
+						'-rtsp_transport','tcp' if ('RTSP_PROTOCOLS' in os.environ and 'tcp' in os.environ.get('RTSP_PROTOCOLS')) else 'udp',
 						'-f','rtsp', 'rtsp://0.0.0.0' + (os.environ.get('RTSP_RTSPADDRESS') if 'RTSP_RTSPADDRESS' in os.environ else ':8554') + '/' + camera.nickname.replace(' ', '-').replace('#', '').lower()]
 					ffmpeg = subprocess.Popen(cmd,stdin=subprocess.PIPE)
 					while ffmpeg.poll() is None:

--- a/app/wyze_bridge.py
+++ b/app/wyze_bridge.py
@@ -1,8 +1,7 @@
 import wyzecam, gc, time, subprocess, threading, warnings, os, pickle, sys, io, wyze_sdk, logging
 
-
 if 'DEBUG_LEVEL' in os.environ:
-	logging.basicConfig(format='%(asctime)s %(name)s - %(levelname)s - %(message)s',datefmt='%Y/%m/%d %X', stream=sys.stdout, level=os.environ.get('DEBUG_LEVEL'))
+	logging.basicConfig(format='%(asctime)s %(name)s - %(levelname)s - %(message)s',datefmt='%Y/%m/%d %X', stream=sys.stdout, level=os.environ.get('DEBUG_LEVEL').upper())
 if 'DEBUG' not in os.environ:
 	warnings.filterwarnings("ignore")
 handler = logging.StreamHandler(stream=sys.stdout)
@@ -14,7 +13,7 @@ log.setLevel(logging.INFO)
 
 class wyze_bridge:
 	def __init__(self):
-		print('STARTING DOCKER-WYZE-BRIDGE v0.4.3')
+		print('STARTING DOCKER-WYZE-BRIDGE v0.5.0')
 		if 'DEBUG_LEVEL' in os.environ:
 			print(f'DEBUG_LEVEL set to {os.environ.get("DEBUG_LEVEL")}')
 
@@ -138,9 +137,9 @@ class wyze_bridge:
 								raise Exception(f'[FFMPEG] {ex}')
 			except Exception as ex:
 				log.info(f'[{camera.nickname}] {ex}')
-				if str(ex) == 'IOTC_ER_CAN_NOT_FIND_DEVICE':
+				if str(ex) == 'IOTC_ER_DEVICE_OFFLINE':
 					offline_time = (offline_time+10 if offline_time < 600 else 30) if 'offline_time' in vars() else 10
-					log.info(f'[{camera.nickname}] Camera offline? Will retry again in {offline_time}s.')
+					log.info(f'[{camera.nickname}] Camera is offline. Will retry again in {offline_time}s.')
 					time.sleep(offline_time)
 			finally:
 				if 'ffmpeg' in locals():

--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -2,7 +2,6 @@ version: '3.8'
 services:
     wyze-bridge:
         restart: always
-        # network_mode: host
         ports:
             - 1935:1935
             - 8554:8554

--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -1,6 +1,7 @@
 version: '3.8'
 services:
     wyze-bridge:
+        container_name: wyze-bridge
         restart: always
         ports:
             - 1935:1935
@@ -9,9 +10,8 @@ services:
         # image: mrlt8/wyze-bridge:latest
         build: 
             context: ./app
-            # args:
-            #     ARM: 1
-            # dockerfile: Dockerfile.arm
+            # Uncomment the followinng line to build for arm
+            # dockerfile: Dockerfile.arm 
         environment:
             - WYZE_EMAIL=
             - WYZE_PASSWORD=

--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -10,6 +10,8 @@ services:
         # image: mrlt8/wyze-bridge:latest
         build: 
             context: ./app
+            # args:
+            #     ARM: 1
             # dockerfile: Dockerfile.arm
         environment:
             - WYZE_EMAIL=

--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -7,10 +7,12 @@ services:
             - 1935:1935
             - 8554:8554
             - 8888:8888
+        # Uncomment to use a pre-built image:
         # image: mrlt8/wyze-bridge:latest
+        # or build from source:
         build: 
             context: ./app
-            # Uncomment the followinng line to build for arm
+            # Uncomment to build for arm
             # dockerfile: Dockerfile.arm 
         environment:
             - WYZE_EMAIL=


### PR DESCRIPTION
Enables "LAN mode" without `network_mode: host`.


Would appreciate if I could get some feedback from non-linux users to see if LAN mode works, as well as some linux user while using ports instead of `network_mode: host`.

```yaml
ports:
    - 1935:1935
    - 8554:8554
    - 8555:8555
```

may need to add:
```yaml
environment:
    - RTSP_PROTOCOLS=tcp
    - LAN_ONLY=TRUE
```