### PR TITLE
Fix IndexErrors for MQTT config

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -55,7 +55,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            mrlt8/wyze-bridge
+            ${{ github.repository_owner }}/wyze-bridge
             ghcr.io/${{ github.repository }}
           tags: |
             type=schedule

--- a/app/rtsp_event.py
+++ b/app/rtsp_event.py
@@ -90,7 +90,7 @@ class rtsp_event:
             if "READ" in self.type:
                 self.mqtt.will_set(self.base + f"clients/{os.getpid()}", None)
             try:
-                self.mqtt.connect(host[0], int(host[1]), 60)
+                self.mqtt.connect(host[0], int(host[1] if len(host)>1 else 1883), 60)
                 self.mqtt.loop_start()
                 self.mqtt_connected = True
             except Exception as ex:

--- a/app/wyze_bridge.py
+++ b/app/wyze_bridge.py
@@ -240,13 +240,14 @@ class wyze_bridge:
                     },
                 }
                 msgs.append((topic, json.dumps(payload)))
-            mqauth = os.getenv("MQTT_AUTH").split(":")
+            mqauth = os.getenv("MQTT_AUTH", ":").split(":")
             try:
+                mqhost = os.getenv("MQTT_HOST", "localhost").split(":")
                 paho.mqtt.publish.multiple(
                     msgs,
-                    hostname=os.getenv("MQTT_HOST").split(":")[0],
-                    port=int(os.getenv("MQTT_HOST").split(":")[1]),
-                    auth={"username": mqauth[0], "password": mqauth[1]},
+                    hostname=mqhost[0],
+                    port=int(mqhost[1]) if len(mqhost)>1 else 1883,
+                    auth=({"username": mqauth[0], "password": mqauth[1]} if self.env_bool("MQTT_AUTH") else None),
                 )
             except Exception as ex:
                 log.warning(f"[MQTT] {ex}")


### PR DESCRIPTION
Allow empty auth in MQTT discovery
Make specifying port optional

These fix the 2 mqtt index errors I found when trying to configure out of the box.