### PR TITLE
enable the rtsp-simple-server api

### DIFF
--- a/app/multi-arch.Dockerfile
+++ b/app/multi-arch.Dockerfile
@@ -23,6 +23,7 @@ RUN mkdir -p /build/app /build/tokens /build/img \
     && echo -n $RTSP_TAG > /build/RTSP_TAG \
     && curl -L https://github.com/aler9/rtsp-simple-server/releases/download/${RTSP_TAG}/rtsp-simple-server_${RTSP_TAG}_linux_${RTSP_ARCH:-amd64}.tar.gz \
     | tar xzf - -C /build/app \
+    && sed -i 's/api: no/api: yes/g' /build/app/rtsp-simple-server.yml
     && cp /tmp/lib/${LIB_ARCH:-amd}.lib /build/usr/local/lib/libIOTCAPIs_ALL.so\
     && rm -rf /tmp/*
 COPY *.py /build/app/


### PR DESCRIPTION
This change will enable the rtsp-simple-server api which will hopefully allow users to create a health check in the 
`docker-compose.yml`
I am hoping this endpoint:
 - https://aler9.github.io/rtsp-simple-server/#operation/pathsList

...will enable docker to check if the streams are available and if not restart the container. 
If not I am hoping another one of the endpoints will work for checking the health of the streams.