### PR TITLE
Adjusted totp parsing to accept alphanumeric chars

### DIFF
--- a/app/wyze_bridge.py
+++ b/app/wyze_bridge.py
@@ -220,7 +220,7 @@ class WyzeBridge:
             if os.path.exists(totp_key) and os.path.getsize(totp_key) > 1:
                 with open(totp_key, "r") as totp_f:
                     verification["code"] = mintotp.totp(
-                        "".join(c for c in totp_f.read() if c.isdigit())
+                        "".join(c for c in totp_f.read() if c.isalnum())
                     )
                 log.info(f"🔏 Using {totp_key} to generate TOTP")
             else:


### PR DESCRIPTION
There was, what I think was meant to be, an improvement in how TOTP parsing was done a few days ago which broke TOTP generation. TOTP strings can be more than just digits, this just changes the parsing to use alpha numerics instead of just digits.