### PR TITLE
Add Cruise command support

### DIFF
--- a/app/wyzebridge/wyze_control.py
+++ b/app/wyzebridge/wyze_control.py
@@ -43,6 +43,8 @@ CAM_CMDS = {
     "set_rotary_down": ("K11000SetRotaryByDegree", 0, -90),
     "set_rotary_right": ("K11000SetRotaryByDegree", 90, 0),
     "set_rotary_left": ("K11000SetRotaryByDegree", -90, 0),
+    "set_pan_cruise_on": ("K11016SetCruise", True),
+    "set_pan_cruise_off": ("K11016SetCruise", False),
     "start_boa": ("K10148StartBoa",),
     "get_motion_tagging": ("K10290GetMotionTagging",),
     "set_motion_tagging_on": ("K10292SetMotionTagging", True),

--- a/app/wyzecam/tutk/tutk_protocol.py
+++ b/app/wyzecam/tutk/tutk_protocol.py
@@ -757,6 +757,22 @@ class K11004ResetRotatePosition(TutkWyzeProtocolMessage):
         return encode(self.code, 1, bytes([self.position]))
 
 
+class K11016SetCruise(TutkWyzeProtocolMessage):
+    """
+    Set switch value for Pan Scan, aka Cruise.
+
+    Parameters:
+    :param enable: Optional Bool. Set True for on, False for off. Defaults to True.
+    """
+
+    def __init__(self, enable: bool = True):
+        super().__init__(11016)
+        self.flag = 1 if enable else 2
+
+    def encode(self) -> bytes:
+        return encode(self.code, 1, bytes([self.enabled]))
+
+
 class K11018SetPTZPosition(TutkWyzeProtocolMessage):
     """
     Set PTZ Position.


### PR DESCRIPTION
K11016 Set Cruise

This command enables or disables the Pan Scan ("Cruise") behavior, where the camera cycles through configured waypoints every 10 seconds.