### PR TITLE
Restructure MQTT/REST 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,61 +39,21 @@ You can then use the web interface at `http://localhost:5000` where localhost is
 
 See [basic usage](#basic-usage) for additional information or visit the [wiki page](https://github.com/mrlt8/docker-wyze-bridge/wiki/Home-Assistant) for additional information on using the bridge as a Home Assistant Add-on.
 
-## What's Changed in v2.1.7
+## What's Changed in v2.2.0
 
-* FIX: WebRTC not loading in the WebUI.
-* UPDATE: MediaMTX to v0.23.2
+⚠️ Breaking changes for MQTT/REST API 
 
-## What's Changed in v2.1.6
-
-* UPDATE: MediaMTX to v0.23.0
-* FIXED: Error reading some events.
-* FIXED: Restart MediaMTX on exit and kill flask on cleanup which could prevent the bridge from restarting.
-
-## What's Changed in v2.1.5
-
-* FIX: set_alarm_on/set_alarm_off was inverted #795. Thanks @iferlive!
-* NEW: `URI_MAC=true` to append last 4 characters of the MAC address to the URI to avoid conflicting URIs when multiple cameras share the same name. #760
-* Home Assistant: Add RECORD_FILE_NAME option #791
-* UPDATE: base image to bullseye.
-
-## What's Changed in v2.1.4
-
-* FIX: Record option would not auto-connect. #784 Thanks @JA16122000!
-* 
-
-## What's Changed in v2.1.2/3
-
-* Increase close on-demand time to 60s to prevent reconnect messages. #643 #750 #764
-* Disable default LL-HLS for compatibility with apple. LL-HLS can still be enabled with `LLHLS=true` which will generate the necessary SSL certificates to work on Apple devices.
-* Disable MQTT if connection refused.
-* UPDATED: MediaMTX to [v0.22.2](https://github.com/aler9/mediamtx/releases/tag/v0.22.2)
+* CHANGED: API commands are now split into topics and payload values for more flexibility.
+* NEW: API commands will initiate connection if not connected.
+* NEW: json payload for API commands.
+* NEW: `PUT`/`POST` methods for REST API.
+* NEW: MQTT topics for each get and set command.
+* NEW: MQTT value gets updated on set command.
+* NEW: start/stop/enable/disable over MQTT.
+* FIXED: camera busy on re-connect.
 
 
-## What's Changed in v2.1.1
 
-* FIXED: WebRTC on UDP Port #772
-* UPDATED: MediaMTX to [v0.22.1](https://github.com/aler9/mediamtx/releases/tag/v0.22.1)
-* ENV Options: Re-enable `ON_DEMAND` to toggle connection mode. #643 #750 #764
-
-## What's Changed in v2.1.0
-
-⚠️ This version updates the backend rtsp-simple-server to [MediaMTX](https://github.com/aler9/mediamtx) which may cause some issues if you're using custom rtsp-simple-server related configs.
-
-* CHANGED: rtsp-simple-server to MediaMTX.
-* ENV Options:
-  * New: `SUB_QUALITY` - Specify the quality to be used for the substream. #755
-  * New: `SNAPSHOT_FORMAT` - Specify the output file format when using `SNAPSHOT` which can be used to create a timelapse/save multiple snapshots. e.g., `SNAPSHOT_FORMAT={cam_name}/%Y-%m-%d/%H-%M.jpg` #757:
-* Home Assistant/MQTT:
-  * Fixed: MQTT auto-discovery error #751
-  * New: Additional entities for each of the cameras.
-  * Changed: Default IMG_DIR to `media/wyze/img/` #660
-
-
-Known Issues/Bugs:
-
-* WebUI Audio: Limited audio compatibility between HLS and WebRTC. May need to force the audio codec to `AUDIO_CODEC=aac` for HLS and `AUDIO_CODEC=libopus` for WebRTC.
-* Substream: SD stream seems to have a stuttering issue due to the hardware encoding on the camera. May need to force a re-encode of the video using `FORCE_ENCODE=true`.
 
 
 [View previous changes](https://github.com/mrlt8/docker-wyze-bridge/releases)

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -1,3 +1,19 @@
+## What's Changed in v2.2.0
+
+⚠️ Breaking changes for MQTT/REST API 
+
+See [wiki](https://github.com/mrlt8/docker-wyze-bridge/wiki/Camera-Commands) for details.
+
+* CHANGED: API commands are now split into topics and payload values for more flexibility.
+* NEW: API commands will initiate connection if not connected.
+* NEW: json payload for API commands.
+* NEW: `PUT`/`POST` methods for REST API.
+* NEW: MQTT topics for each get and set command.
+* NEW: MQTT value gets updated on set command.
+* NEW: start/stop/enable/disable over MQTT.
+* FIXED: camera busy on re-connect.
+
+
 ## What's Changed in v2.1.7
 
 * FIX: WebRTC not loading in the WebUI.

--- a/app/config.json
+++ b/app/config.json
@@ -4,7 +4,7 @@
     "slug": "docker-wyze-bridge",
     "url": "https://github.com/mrlt8/docker-wyze-bridge",
     "image": "mrlt8/wyze-bridge",
-    "version": "2.1.7",
+    "version": "2.2.0",
     "arch": [
         "armv7",
         "aarch64",

--- a/app/frontend.py
+++ b/app/frontend.py
@@ -121,12 +121,13 @@ def create_app():
 
     @app.route("/api/<cam_name>/<cam_cmd>", methods=["GET", "PUT", "POST"])
     @app.route("/api/<cam_name>/<cam_cmd>/<payload>")
-    def api_cam_control(cam_name: str, cam_cmd: str, payload: str = ""):
+    def api_cam_control(cam_name: str, cam_cmd: str, payload: str | dict = ""):
         """API Endpoint to send tutk commands to the camera."""
-        if request.values:
-            payload = next(request.values.values())
+        if args := request.values:
+            payload = args.to_dict() if len(args) > 1 else next(args.values())
         elif request.is_json:
-            payload = list(request.get_json().values())[0]
+            json = request.get_json()
+            payload = json if len(json) > 1 else list(json.values())[0]
         elif request.data:
             payload = request.data.decode()
 

--- a/app/frontend.py
+++ b/app/frontend.py
@@ -123,17 +123,6 @@ def create_app():
     @app.route("/api/<cam_name>/<cam_cmd>/<payload>")
     def api_cam_control(cam_name: str, cam_cmd: str, payload: str = ""):
         """API Endpoint to send tutk commands to the camera."""
-        if cam_cmd == "status":
-            return {"status": wb.streams.get_status(cam_name)}
-        if cam_cmd == "start":
-            return {"status": wb.streams.start(cam_name)}
-        if cam_cmd == "stop":
-            return {"status": wb.streams.stop(cam_name)}
-        if cam_cmd == "disable":
-            return {"status": wb.streams.disable(cam_name)}
-        if cam_cmd == "enable":
-            return {"status": wb.streams.enable(cam_name)}
-
         if request.values:
             payload = next(request.values.values())
         elif request.is_json:
@@ -141,7 +130,7 @@ def create_app():
         elif request.data:
             payload = request.data.decode()
 
-        return wb.streams.send_cmd(cam_name, cam_cmd, payload)
+        return wb.streams.send_cmd(cam_name, cam_cmd.lower(), payload)
 
     @app.route("/signaling/<string:name>")
     def webrtc_signaling(name):

--- a/app/frontend.py
+++ b/app/frontend.py
@@ -196,7 +196,7 @@ def create_app():
         """
         if restart_cmd == "cameras":
             wb.streams.stop_all()
-            wb.streams.monitor_streams()
+            wb.streams.monitor_streams(wb.rtsp.health_check)
         elif restart_cmd == "rtsp_server":
             wb.rtsp.restart()
         elif restart_cmd == "all":

--- a/app/static/site.js
+++ b/app/static/site.js
@@ -652,11 +652,12 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // cam control
   document.querySelectorAll(".cam-control").forEach((e) => {
-    let cam = e.dataset.cam;
+    let { cam } = e.dataset;
     e.querySelectorAll(".button").forEach((button) => {
       button.addEventListener("click", () => {
         button.classList.add("is-loading");
-        fetch(`api/${cam}/${button.dataset.cmd}`)
+        const { payload } = button.dataset
+        fetch(`api/${cam}/${button.dataset.cmd}${payload ? `/${payload}` : ''}`)
           .then((resp) => resp.json())
           .then((data) => { sendNotification(cam, `${button.dataset.cmd}: ${data.status}`, ["error", false].includes(data.status) ? "danger" : "primary") })
           .catch((error) => { sendNotification(cam, `${button.dataset.cmd}: ${error.message}`, "danger") })

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -267,9 +267,9 @@
                                     </div>
                                     <p class="menu-label dropdown-item">Night Vision</p>
                                     <div class="buttons are-small is-centered">
-                                        <button class="button" data-cmd="set_night_vision_on">On</button>
-                                        <button class="button" data-cmd="set_night_vision_off">Off</button>
-                                        <button class="button" data-cmd="set_night_vision_auto">Auto</button>
+                                        <button class="button" data-cmd="night_vision" data-payload="on">On</button>
+                                        <button class="button" data-cmd="night_vision" data-payload="off">Off</button>
+                                        <button class="button" data-cmd="night_vision" data-payload="auto">Auto</button>
                                     </div>
                                 </div>
                             </div>

--- a/app/wyzebridge/mqtt.py
+++ b/app/wyzebridge/mqtt.py
@@ -9,7 +9,7 @@ import paho.mqtt.publish
 from wyzebridge.bridge_utils import env_bool
 from wyzebridge.config import IMG_PATH, MQTT_DISCOVERY, VERSION
 from wyzebridge.logging import logger
-from wyzebridge.wyze_control import GET_CMDS, GET_PAYLOAD, SET_CMDS
+from wyzebridge.wyze_commands import GET_CMDS, GET_PAYLOAD, SET_CMDS
 from wyzecam import WyzeCamera
 
 MQTT_ENABLED = bool(env_bool("MQTT_HOST"))
@@ -42,8 +42,6 @@ def wyze_discovery(cam: WyzeCamera, cam_uri: str) -> None:
 
     if MQTT_DISCOVERY:
         base_payload = {
-            "availability_topic": f"{base}state",
-            "payload_not_available": "stopped",
             "device": {
                 "name": f"Wyze Cam {cam.nickname}",
                 "connections": [["mac", cam.mac]],
@@ -57,6 +55,8 @@ def wyze_discovery(cam: WyzeCamera, cam_uri: str) -> None:
 
         entities = {
             "preview": {
+                "availability_topic": f"{base}state",
+                "payload_not_available": "stopped",
                 "type": "camera",
                 "payload": {
                     "topic": f"{base}image",
@@ -68,7 +68,7 @@ def wyze_discovery(cam: WyzeCamera, cam_uri: str) -> None:
                 "payload": {
                     "state_topic": f"{base}irled",
                     "command_topic": f"{base}irled/set",
-                    "payload_on": 3,
+                    "payload_on": 1,
                     "payload_off": 2,
                     "icon": "mdi:lightbulb-night",
                 },
@@ -107,7 +107,6 @@ def wyze_discovery(cam: WyzeCamera, cam_uri: str) -> None:
                 "name"
             ] = f"Wyze Cam {cam.nickname} {' '.join(entity.upper().split('_'))}"
             payload["uniq_id"] = f"WYZE{cam.mac}{entity.upper()}"
-
             msgs.append((topic, json.dumps(payload)))
     send_mqtt(msgs)
 

--- a/app/wyzebridge/mqtt.py
+++ b/app/wyzebridge/mqtt.py
@@ -193,6 +193,8 @@ def _on_message(client, callback, msg):
     payload = msg.payload.decode()
     with contextlib.suppress(json.JSONDecodeError):
         json_msg = json.loads(payload)
+        if not isinstance(json_msg, dict):
+            raise json.JSONDecodeError("NOT a dictionary", payload, 0)
         payload = json_msg if len(json_msg) > 1 else next(iter(json_msg.values()))
 
     resp = callback(cam, topic, payload if include_payload else "")

--- a/app/wyzebridge/mqtt.py
+++ b/app/wyzebridge/mqtt.py
@@ -190,6 +190,11 @@ def _on_message(client, callback, msg):
     cam, topic, action = msg_topic[-3:]
     include_payload = action == "set" or topic in GET_PAYLOAD
 
-    resp = callback(cam, topic, msg.payload.decode() if include_payload else "")
+    payload = msg.payload.decode()
+    with contextlib.suppress(json.JSONDecodeError):
+        json_msg = json.loads(payload)
+        payload = json_msg if len(json_msg) > 1 else next(iter(json_msg.values()))
+
+    resp = callback(cam, topic, payload if include_payload else "")
     if resp.get("status") != "success":
         logger.info(f"[MQTT] {resp}")

--- a/app/wyzebridge/rtsp_event.py
+++ b/app/wyzebridge/rtsp_event.py
@@ -53,13 +53,13 @@ class RtspEvent:
             return
 
         if event.lower() == "start":
-            self.streams.start(uri)
+            self.streams.get(uri).start()
         elif event.lower() == "read":
             read_event(uri, status)
         elif event.lower() == "ready":
             ready_event(uri, status)
             if status == "0":
-                self.streams.stop(uri)
+                self.streams.get(uri).stop()
 
 
 def read_event(camera: str, status: str):

--- a/app/wyzebridge/stream.py
+++ b/app/wyzebridge/stream.py
@@ -47,7 +47,7 @@ class Stream(Protocol):
     def status(self) -> str:
         ...
 
-    def send_cmd(self, cmd: str, value: str = "") -> dict:
+    def send_cmd(self, cmd: str, value: str | dict = "") -> dict:
         ...
 
 
@@ -146,13 +146,13 @@ class StreamManager:
     def get_sse_status(self) -> dict:
         return {uri: cam.status() for uri, cam in self.streams.items()}
 
-    def send_cmd(self, cam_name: str, cmd: str, payload: str = "") -> dict:
+    def send_cmd(self, cam_name: str, cmd: str, payload: str | dict = "") -> dict:
         """
         Send a command directly to the camera and wait for a response.
 
         Parameters:
         - cam_name (str): uri-friendly name of the camera.
-        - cmd (str): The tutk command to send.
+        - cmd (str): The camera/tutk command to send.
         - payload (str): value for the tutk command.
 
         Returns:
@@ -162,13 +162,6 @@ class StreamManager:
 
         if not (stream := self.get(cam_name)):
             return resp | {"response": "Camera not found"}
-        if cmd in {"status", "start", "stop", "disable", "enable"}:
-            response = getattr(stream, cmd)()
-            publish_message(f"{cam_name}/{cmd}", response)
-            return resp | {
-                "status": "success" if response else "error",
-                "response": response,
-            }
 
         if cam_resp := stream.send_cmd(cmd, payload):
             status = cam_resp.get("value") if cam_resp.get("status") == "success" else 0

--- a/app/wyzebridge/wyze_commands.py
+++ b/app/wyzebridge/wyze_commands.py
@@ -1,0 +1,43 @@
+GET_CMDS = {
+    "status": None,
+    "take_photo": "K10058TakePhoto",
+    "irled": "K10044GetIRLEDStatus",
+    "night_vision": "K10040GetNightVisionStatus",
+    "status_light": "K10030GetNetworkLightStatus",
+    "camera_time": "K10090GetCameraTime",
+    "night_switch": "K10624GetAutoSwitchNightType",
+    "alarm": "K10632GetAlarmFlashing",
+    "start_boa": "K10148StartBoa",
+    "pan_cruise": "K11014GetCruise",
+    "motion_tracking": "K11020GetMotionTracking",
+    "motion_tagging": "K10290GetMotionTagging",
+    "camera_info": "K10020CheckCameraInfo",
+    "rtsp": "K10604GetRtspParam",
+    "param_info": "K10020CheckCameraParams",  # Requires a Payload
+}
+
+# These GET_CMDS can include a payload:
+GET_PAYLOAD = {"param_info"}
+
+SET_CMDS = {
+    "start": None,
+    "stop": None,
+    "disable": None,
+    "enable": None,
+    "irled": "K10046SetIRLEDStatus",
+    "night_vision": "K10042SetNightVisionStatus",
+    "status_light": "K10032SetNetworkLightStatus",
+    "camera_time": "K10092SetCameraTime",
+    "night_switch": "K10626SetAutoSwitchNightType",
+    "alarm": "K10630SetAlarmFlashing",
+    "rotary_action": "K11002SetRotaryByAction",
+    "rotary_degree": "K11000SetRotaryByDegree",
+    "reset_rotation": "K11004ResetRotatePosition",
+    "pan_cruise": "K11016SetCruise",
+    "motion_tracking": "K10292SetMotionTagging",
+    "motion_tagging": "K10292SetMotionTagging",
+    "fps": "K10052SetFPS",
+    "rtsp": "K10600SetRtspSwitch",
+}
+
+CMD_VALUES = {"on": 1, "off": 2, "auto": 3, "true": 1, "false": 2}

--- a/app/wyzebridge/wyze_commands.py
+++ b/app/wyzebridge/wyze_commands.py
@@ -40,4 +40,14 @@ SET_CMDS = {
     "rtsp": "K10600SetRtspSwitch",
 }
 
-CMD_VALUES = {"on": 1, "off": 2, "auto": 3, "true": 1, "false": 2}
+CMD_VALUES = {
+    "on": 1,
+    "off": 2,
+    "auto": 3,
+    "true": 1,
+    "false": 2,
+    "left": (-90, 0),
+    "right": (90, 0),
+    "up": (0, 90),
+    "down": (0, -90),
+}

--- a/app/wyzebridge/wyze_control.py
+++ b/app/wyzebridge/wyze_control.py
@@ -15,6 +15,7 @@ from wyzebridge.logging import logger
 from wyzecam import WyzeIOTCSession, WyzeIOTCSessionState, tutk_protocol
 
 GET_CMDS = {
+    "status": None,
     "take_photo": "K10058TakePhoto",
     "irled": "K10044GetIRLEDStatus",
     "night_vision": "K10040GetNightVisionStatus",
@@ -31,6 +32,10 @@ GET_CMDS = {
 }
 
 SET_CMDS = {
+    "start": None,
+    "stop": None,
+    "disable": None,
+    "enable": None,
     "irled": "K10046SetIRLEDStatus",
     "night_vision": "K10042SetNightVisionStatus",
     "status_light": "K10032SetNetworkLightStatus",

--- a/app/wyzebridge/wyze_control.py
+++ b/app/wyzebridge/wyze_control.py
@@ -257,12 +257,17 @@ def lookup_cmd(cmd: tuple[str, Optional[str | dict]] | str, log: bool = True) ->
             return None, topic, ex, payload_str
 
     payload = []
-    for i in str(payload_str).split(","):
-        value = i.strip().lower()
-        if value.strip("-").isdigit():
-            payload.append(int(value))
-        elif value in CMD_VALUES:
-            payload.append(CMD_VALUES.get(value))
+    print(payload_str)
+    print(type(payload_str))
+    if isinstance(payload_str, int):
+        payload.append(payload_str)
+    elif payload_str and (value := CMD_VALUES.get(payload_str.strip().lower())):
+        payload = [value] if isinstance(value, int) else value
+    elif payload_str:
+        payload = [
+            int(v) for v in payload_str.split(",") if v.strip().strip("-").isdigit()
+        ]
+
     return tutk_msg(*payload), topic, payload, payload_str
 
 

--- a/app/wyzebridge/wyze_stream.py
+++ b/app/wyzebridge/wyze_stream.py
@@ -18,6 +18,7 @@ from wyzebridge.logging import logger
 from wyzebridge.mqtt import send_mqtt, update_mqtt_state, wyze_discovery
 from wyzebridge.webhooks import ifttt_webhook
 from wyzebridge.wyze_api import WyzeApi
+from wyzebridge.wyze_commands import GET_CMDS, SET_CMDS
 from wyzebridge.wyze_control import camera_control
 from wyzecam import TutkError, WyzeAccount, WyzeCamera, WyzeIOTC, WyzeIOTCSession
 
@@ -260,6 +261,8 @@ class WyzeStream:
 
         if env_bool("disable_control"):
             return {"response": "control disabled"}
+        if cmd not in GET_CMDS | SET_CMDS:
+            return {"response": "invalid command"}
         if on_demand := not self.connected:
             logger.info(f"[CONTROL] Connecting to {self.uri}")
             self.start()

--- a/app/wyzebridge/wyze_stream.py
+++ b/app/wyzebridge/wyze_stream.py
@@ -250,7 +250,7 @@ class WyzeStream:
 
     def send_cmd(self, cmd: str, value: str | dict = "") -> dict:
         if cmd in {"status", "start", "stop", "disable", "enable"}:
-            logger.info(f"[{self.uri}][CONTROL] {cmd.upper()}")
+            logger.info(f"[CONTROL] {self.uri}:{cmd.upper()}")
             response = getattr(self, cmd)()
             return {
                 "status": "success" if response else "error",
@@ -261,6 +261,7 @@ class WyzeStream:
         if env_bool("disable_control"):
             return {"response": "control disabled"}
         if on_demand := not self.connected:
+            logger.info(f"[CONTROL] Connecting to {self.uri}")
             self.start()
             while not self.connected and time() - self.start_time < 10:
                 sleep(0.1)
@@ -274,6 +275,7 @@ class WyzeStream:
             return {"response": "timed out"}
         finally:
             if on_demand:
+                logger.info(f"[CONTROL] Disconnecting from {self.uri}")
                 self.stop()
         return cam_resp.pop(cmd, None) or {"response": "could not get result"}
 

--- a/app/wyzebridge/wyze_stream.py
+++ b/app/wyzebridge/wyze_stream.py
@@ -246,6 +246,7 @@ class WyzeStream:
 
     def send_cmd(self, cmd: str, value: str | dict = "") -> dict:
         if cmd in {"status", "start", "stop", "disable", "enable"}:
+            logger.info(f"[CONTROL] {cmd.upper()}")
             response = getattr(self, cmd)()
             return {
                 "status": "success" if response else "error",

--- a/app/wyzebridge/wyze_stream.py
+++ b/app/wyzebridge/wyze_stream.py
@@ -244,7 +244,15 @@ class WyzeStream:
             return {}
         return self.camera.camera_info.get("boa_info", {})
 
-    def send_cmd(self, cmd: str, value: str = "") -> dict:
+    def send_cmd(self, cmd: str, value: str | dict = "") -> dict:
+        if cmd in {"status", "start", "stop", "disable", "enable"}:
+            response = getattr(self, cmd)()
+            return {
+                "status": "success" if response else "error",
+                "response": response,
+                "value": response,
+            }
+
         if (
             env_bool("disable_control")
             or not self.connected

--- a/app/wyzebridge/wyze_stream.py
+++ b/app/wyzebridge/wyze_stream.py
@@ -19,8 +19,7 @@ from wyzebridge.mqtt import send_mqtt, update_mqtt_state, wyze_discovery
 from wyzebridge.webhooks import ifttt_webhook
 from wyzebridge.wyze_api import WyzeApi
 from wyzebridge.wyze_control import camera_control
-from wyzecam import (TutkError, WyzeAccount, WyzeCamera, WyzeIOTC,
-                     WyzeIOTCSession)
+from wyzecam import TutkError, WyzeAccount, WyzeCamera, WyzeIOTC, WyzeIOTCSession
 
 NET_MODE = {0: "P2P", 1: "RELAY", 2: "LAN"}
 
@@ -109,7 +108,7 @@ class WyzeStream:
     @state.setter
     def state(self, value):
         self._state.value = value.value if isinstance(value, StreamStatus) else value
-        update_mqtt_state(self.uri, self.get_status())
+        update_mqtt_state(self.uri, self.status())
 
     @property
     def connected(self) -> bool:
@@ -200,7 +199,7 @@ class WyzeStream:
         self.camera = cam
         return True
 
-    def get_status(self) -> str:
+    def status(self) -> str:
         try:
             return StreamStatus(self._state.value).name.lower()
         except ValueError:

--- a/app/wyzecam/tutk/tutk_protocol.py
+++ b/app/wyzecam/tutk/tutk_protocol.py
@@ -336,15 +336,18 @@ class K10032SetNetworkLightStatus(TutkWyzeProtocolMessage):
     """
     A message used to set the Camera Status Light on the camera.
 
-    :param enabled: boolean to set the camera light on/off.
+    Parameters:
+    -  value (int): 1 for on; 2 for off.
     """
 
-    def __init__(self, light_status: bool):
+    def __init__(self, value: int):
         super().__init__(10032)
-        self.light_status: int = 1 if light_status else 2
+
+        assert 0 <= value <= 2, "value must be 1 or 2"
+        self.value: int = value
 
     def encode(self) -> bytes:
-        return encode(self.code, 1, bytearray([self.light_status]))
+        return encode(self.code, 1, bytes([self.value]))
 
 
 class K10040GetNightVisionStatus(TutkWyzeProtocolMessage):
@@ -528,7 +531,7 @@ class K10092SetCameraTime(TutkWyzeProtocolMessage):
     This will use the current time on the bridge +1 to set the time on the camera.
     """
 
-    def __init__(self):
+    def __init__(self, _=None):
         super().__init__(10092)
 
     def encode(self) -> bytes:
@@ -552,15 +555,18 @@ class K10292SetMotionTagging(TutkWyzeProtocolMessage):
     """
     A message used to enable/disable motion tagging (green box around motion).
 
-    :param enabled: boolean to turn on/off motion tagging.
+    Parameters:
+    -  value (int): 1 for on; 2 for off.
     """
 
-    def __init__(self, enabled: bool):
+    def __init__(self, value: int):
         super().__init__(10292)
-        self.enabled = 1 if enabled else 2
+
+        assert 0 <= value <= 2, "value must be 1 or 2"
+        self.value: int = value
 
     def encode(self) -> bytes:
-        return encode(self.code, 1, bytes([self.enabled]))
+        return encode(self.code, 1, bytes([self.value]))
 
 
 class K10620CheckNight(TutkWyzeProtocolMessage):
@@ -606,17 +612,19 @@ class K10626SetAutoSwitchNightType(TutkWyzeProtocolMessage):
 
 class K10630SetAlarmFlashing(TutkWyzeProtocolMessage):
     """
-    A message used to control the alarm/siren on the camera.
+    A message used to control the alarm AND siren on the camera.
 
-    :param enabled: boolean to turn on/off alarm/siren.
+    Parameters:
+    -  value (int):  1 to turn on alarm and siren; 2 to turn off alarm and siren.
     """
 
-    def __init__(self, enabled: bool):
+    def __init__(self, value: int):
         super().__init__(10630)
-        self.enabled: int = 1 if enabled else 2
+        assert 0 <= value <= 2, "value must be 1 or 2"
+        self.value: int = value
 
     def encode(self) -> bytes:
-        return encode(self.code, 2, bytes([self.enabled, self.enabled]))
+        return encode(self.code, 2, bytes([self.value, self.value]))
 
 
 class K10632GetAlarmFlashing(TutkWyzeProtocolMessage):
@@ -668,15 +676,17 @@ class K10600SetRtspSwitch(TutkWyzeProtocolMessage):
     """
     Set switch value for RTSP server on camera.
 
-    :param enable: Optional Bool. Set True for on, False for off. Defaults to True.
+    Parameters:
+    -  value (int): 1 for on; 2 for off. Defaults to True.
     """
 
-    def __init__(self, enable: bool = True):
+    def __init__(self, value: int = 1):
         super().__init__(10600)
-        self.enable = 1 if enable else 0
+        assert 0 <= value <= 2, "value must be 1 or 2"
+        self.value: int = value
 
     def encode(self) -> bytes:
-        return encode(self.code, 1, bytes([self.enable]))
+        return encode(self.code, 1, bytes([self.value]))
 
 
 class K10604GetRtspParam(TutkWyzeProtocolMessage):
@@ -775,15 +785,17 @@ class K11016SetCruise(TutkWyzeProtocolMessage):
     Set switch value for Pan Scan, aka Cruise.
 
     Parameters:
-    :param enable: Optional Bool. Set True for on, False for off. Defaults to True.
+    -  value (int): 1 for on; 2 for off. Defaults to On.
     """
 
-    def __init__(self, enable: bool = True):
+    def __init__(self, value: int):
         super().__init__(11016)
-        self.flag = 1 if enable else 2
+
+        assert 0 <= value <= 2, "value must be 1 or 2"
+        self.value: int = value
 
     def encode(self) -> bytes:
-        return encode(self.code, 1, bytes([self.enabled]))
+        return encode(self.code, 1, bytes([self.value]))
 
 
 class K11018SetPTZPosition(TutkWyzeProtocolMessage):
@@ -825,15 +837,18 @@ class K11022SetMotionTracking(TutkWyzeProtocolMessage):
     A message used to enable/disable motion tracking (camera pans
     to follow detected motion).
 
-    :param enabled: boolean to turn on/off motion tracking.
+    Parameters:
+    -  value (int): 1 for on; 2 for off.
     """
 
-    def __init__(self, enabled: bool):
+    def __init__(self, value: int):
         super().__init__(11022)
-        self.enabled = 1 if enabled else 2
+
+        assert 0 <= value <= 2, "value must be 1 or 2"
+        self.value: int = value
 
     def encode(self) -> bytes:
-        return encode(self.code, 1, bytes([self.enabled]))
+        return encode(self.code, 1, bytes([self.value]))
 
 
 def encode(code: int, data_len: int, data: Optional[bytes]) -> bytes:

--- a/app/wyzecam/tutk/tutk_protocol.py
+++ b/app/wyzecam/tutk/tutk_protocol.py
@@ -284,16 +284,19 @@ class K10020CheckCameraInfo(TutkWyzeProtocolMessage):
     """
     A command used to read the current settings of the camera.
 
-    Not terribly well understood.
+    Parameters:
+    - count (int): The number of camera parameters to read.  Defaults to 99.
+
+    Returns:
+    - A json object with the camera parameters.
     """
 
-    def __init__(self):
+    def __init__(self, count: int = 99):
         super().__init__(10020)
+        self.count = count
 
     def encode(self) -> bytes:
-        arr = bytearray()
-        arr.append(50)
-        arr.extend(range(1, 51))
+        arr = bytes([self.count, *range(1, self.count + 1)])
         return encode(self.code, len(arr), arr)
 
     def parse_response(self, resp_data):

--- a/app/wyzecam/tutk/tutk_protocol.py
+++ b/app/wyzecam/tutk/tutk_protocol.py
@@ -757,6 +757,19 @@ class K11004ResetRotatePosition(TutkWyzeProtocolMessage):
         return encode(self.code, 1, bytes([self.position]))
 
 
+class K11014GetCruise(TutkWyzeProtocolMessage):
+    """
+    Get switch value for Pan Scan, aka Cruise.
+
+    :return: returns the current cruise status:
+        - 1: On
+        - 2: Off
+    """
+
+    def __init__(self):
+        super().__init__(11014)
+
+
 class K11016SetCruise(TutkWyzeProtocolMessage):
     """
     Set switch value for Pan Scan, aka Cruise.


### PR DESCRIPTION
## Get Value

### MQTT
```
TOPIC: 
wyzebridge/<cam_name>/<command_topic>/get 

RESPONSE TOPIC:
wyzebridge/<cam_name>/<command_topic> # Value only; 0 for error.
```

### REST
```
REQUEST:
GET http://<localhost>:5000/api/<cam_name>/<command_topic>

RESPONSE:
json 
```

## Set Value

### MQTT
```
TOPIC: 
wyzebridge/<cam_name>/<command_topic>/set 

RESPONSE TOPIC:
wyzebridge/<cam_name>/<command_topic> # Value only; 0 for error.
```

### REST
```
REQUEST:
- GET http://<localhost>:5000/api/<cam_name>/<command_topic>/<value>
- GET http://<localhost>:5000/api/<cam_name>/<command_topic>?<key>=<value>
- POST/PUT http://<localhost>:5000/api/<cam_name>/<command_topic> 
    --data <value> 
    or
    --header 'Content-Type: application/json' \
    --data '{"<key>":"<value>"}'
    or
    --header 'Content-Type: application/x-www-form-urlencoded' \
    --data <key>=<value>

RESPONSE:
json 
```
## Available Topics

GET:
https://github.com/mrlt8/docker-wyze-bridge/blob/a4866ac8602532f09b715f6df43b962123a2336a/app/wyzebridge/wyze_commands.py#L2-L16

SET:
https://github.com/mrlt8/docker-wyze-bridge/blob/a4866ac8602532f09b715f6df43b962123a2336a/app/wyzebridge/wyze_commands.py#L23-L40



## Payload Value

The payload value for both REST and MQTT can be one of the following types: 

 - `string`: "on", "off", "auto", "true", "false", "left", "right", "up", "down", a single integer value, or multiple comma-separated integer values. For example, "0,-90" or "1,2,50".
 - `integer`: Single value. Typically `1` for on, `2` for off, `3` for auto.
 - `json`: If multiple key-value pairs are set, they will be passed directly to `tutk_protocol` (e.g., `{"horizontal":-90, "vertical":0}`). However, if only one key-value pair is set, the API will use the value without the key (e.g., `{"anything":"auto"}`).

To pass multiple values, use a comma-separated string. For example, if you want to rotate left you could use the string value "-90,0".

