### PR TITLE
Cache supported commands for each WyzeCamera

### DIFF
--- a/app/wyzecam/api_models.py
+++ b/app/wyzecam/api_models.py
@@ -117,6 +117,7 @@ class WyzeCamera(BaseModel):
     mac: str
     product_model: str
     camera_info: Optional[dict[str, Any]] = None
+    supported_commands: Optional[list[str]] = None
     nickname: Optional[str]
     timezone_name: Optional[str]
     firmware_ver: Optional[str]
@@ -126,9 +127,16 @@ class WyzeCamera(BaseModel):
     parent_mac: Optional[str]
     thumbnail: Optional[str]
 
-    def set_camera_info(self, info: dict[str, Any]) -> None:
+    def set_camera_info(self, info: dict[str, Any], commands: list[str] = None) -> None:
         # Called internally as part of WyzeIOTC.connect_and_auth()
         self.camera_info = info
+        self.supported_commands = commands
+
+    def supports_command(self, command: int) -> bool:
+        """Return whether the command is supported by this camera."""
+        if self.supported_commands:
+            return str(command) in self.supported_commands
+        return False
 
     @property
     def name_uri(self) -> str:

--- a/app/wyzecam/iotc.py
+++ b/app/wyzecam/iotc.py
@@ -35,6 +35,7 @@ from wyzecam.tutk.tutk_protocol import (
     K10020CheckCameraParams,
     K10052DBSetResolvingBit,
     K10056SetResolvingBit,
+    get_supported_commands,
     respond_to_ioctrl_10001,
 )
 
@@ -1000,7 +1001,10 @@ class WyzeIOTCSession:
                 if auth_response["connectionRes"] != "1":
                     warnings.warn(f"AUTH FAILED: {auth_response}")
                     raise ValueError("AUTH_FAILED")
-                self.camera.set_camera_info(auth_response["cameraInfo"])
+                self.camera.set_camera_info(
+                    auth_response["cameraInfo"],
+                    get_supported_commands(self.camera.product_model, challenge.resp_protocol),
+                )
                 frame_bit = self.preferred_frame_size, self.preferred_bitrate
                 if self.camera.product_model in (
                     "WYZEDB3",

--- a/app/wyzecam/tutk/tutk_protocol.py
+++ b/app/wyzecam/tutk/tutk_protocol.py
@@ -1073,7 +1073,7 @@ def respond_to_ioctrl_10001(
     return response
 
 
-def supports(product_model, protocol, command):
+def get_supported_commands(product_model, protocol):
     with open(project_root / "device_config.json") as f:
         device_config = json.load(f)
     commands_db = device_config["supportedCommands"]
@@ -1090,5 +1090,9 @@ def supports(product_model, protocol, command):
         for k in commands_db[product_model]:
             if int(k) <= int(protocol):
                 supported_commands.extend(commands_db[product_model][k])
+    return supported_commands
 
+
+def supports(product_model, protocol, command):
+    supported_commands = get_supported_commands(product_model, protocol)
     return str(command) in supported_commands


### PR DESCRIPTION
This loads the `device_config.json` and caches the list of supported commands for each camera. As of today this list is checked only in `respond_to_ioctrl_10001` for command `10008`:
```
    if supports(product_model, protocol, 10008):
        response: TutkWyzeProtocolMessage = K10008ConnectUserAuth(
            challenge_response, phone_id, open_userid, open_audio=enable_audio
        )
    else:
        response = K10002ConnectAuth(challenge_response, mac, open_audio=enable_audio)
```

Once this list is loaded for the current camera, it can then be queried later by checking:
```
if cam.supports_command(11018):
  # has PTZ support
```

A possible enhancement could be made if memory consumption is a concern, that would only keep track of a smaller list of high-value commands (like PTZ commands in this example), rather than the full list of commands from `device_config.json`. Since most functionality that would need to check this would only be checking for a relatively small list of commands.

This relates to https://github.com/mrlt8/docker-wyze-bridge/issues/921#issuecomment-1637183749 as a prerequisite to publishing optional entities during discovery, such as the "Pan Cruise" switch, which should be published only if the camera supports it.

NOTE: I do not know what your typical dev environment looks like, or the best way to test changes before submitting a PR. I use the bridge as a HA add-on, so I don't know the best way to spin up a test instance outside of HA just for testing. I also did not see a .github workflow that runs any kind of code style checks, unit tests, or simple "does it work at all" checks. I'm happy to run some sanity checks on my own if you have any documentation for best practices for PRs.