### PR TITLE
Add HttpOnly flag to cookies

### DIFF
--- a/app/frontend.py
+++ b/app/frontend.py
@@ -98,16 +98,17 @@ def create_app():
             )
         )
 
-        resp.set_cookie("number_of_columns", str(number_of_columns))
-        resp.set_cookie("refresh_period", str(refresh_period))
-        resp.set_cookie("show_video", "1" if show_video else "")
-        resp.set_cookie("video", video_format)
+        resp.set_cookie("number_of_columns", str(number_of_columns), httponly=True)
+        resp.set_cookie("refresh_period", str(refresh_period), httponly=True)
+        resp.set_cookie("show_video", "1" if show_video else "", httponly=True)
+        resp.set_cookie("video", video_format, httponly=True)
         fullscreen = "fullscreen" in request.args or bool(
             request.cookies.get("fullscreen")
         )
-        resp.set_cookie("fullscreen", "1" if fullscreen else "")
+        resp.set_cookie("fullscreen", "1" if fullscreen else "", httponly=True)
         if order := request.args.get("order"):
-            resp.set_cookie("camera_order", quote_plus(order))
+            resp.set_cookie("camera_order", quote_plus(order), httponly=True)
+
 
         return resp
 


### PR DESCRIPTION
add `httponly = True` flag to the `set_cookie()` calls

Security scan revealed that the above flag is not set correctly. Scan Result shown below:

![image](https://github.com/mrlt8/docker-wyze-bridge/assets/5826484/39fa97b8-1a84-4121-bc69-366edcc6ef77)

After implementing the changes, httpOnly flag is set correctly as seen in Dev Tools->Network->Cookies:

![image](https://github.com/mrlt8/docker-wyze-bridge/assets/5826484/7376780f-2cdc-4322-b8dc-1dd2680acede)
