### PR TITLE
v2.9.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ You can then use the web interface at `http://localhost:5000` where localhost is
 
 See [basic usage](#basic-usage) for additional information or visit the [wiki page](https://github.com/mrlt8/docker-wyze-bridge/wiki/Home-Assistant) for additional information on using the bridge as a Home Assistant Add-on.
 
+## What's Changed in v2.9.3
+
+- FIX: Clear the retain flag from MQTT Discovery which was causing commands to be resent to the bridge on startup for some users. (#1182)
+- Ignore commands when connection is stopping.
+
 ## What's Changed in v2.9.2
 
 - Improved video connection stability and audio sync.  #1175 #1196 #1194 #1193 #1186 Thanks @vipergts450!

--- a/app/wyzebridge/config.py
+++ b/app/wyzebridge/config.py
@@ -41,7 +41,7 @@ LLHLS: bool = env_bool("LLHLS", style="bool")
 COOLDOWN = env_bool("OFFLINE_TIME", "10", style="int")
 
 
-BOA_INTERVAL: int = env_bool("boa_interval", "15", style="int")
+BOA_INTERVAL: int = env_bool("boa_interval", "20", style="int")
 BOA_COOLDOWN: int = env_bool("boa_cooldown", "20", style="int")
 
 MOTION: bool = env_bool("motion_api", style="bool")

--- a/app/wyzebridge/wyze_stream.py
+++ b/app/wyzebridge/wyze_stream.py
@@ -124,7 +124,7 @@ class WyzeStream:
         state = time() - self.motion_ts < 20
         if self._motion and not state:
             self._motion = state
-            publish_messages([(f"{MQTT_TOPIC}/{self.uri}/motion", 2)])
+            publish_messages([(f"{MQTT_TOPIC}/{self.uri}/motion", 2, 0, True)])
         return state
 
     @motion.setter
@@ -133,8 +133,8 @@ class WyzeStream:
         self.motion_ts = value
         publish_messages(
             [
-                (f"{MQTT_TOPIC}/{self.uri}/motion", 1),
-                (f"{MQTT_TOPIC}/{self.uri}/motion_ts", value),
+                (f"{MQTT_TOPIC}/{self.uri}/motion", 1, 0, True),
+                (f"{MQTT_TOPIC}/{self.uri}/motion_ts", value, 0, True),
             ]
         )
 
@@ -497,7 +497,7 @@ def get_cam_params(sess: WyzeIOTCSession, uri: str) -> tuple[str, dict]:
         (f"{MQTT_TOPIC}/{uri.lower()}/net_mode", net_mode),
         (f"{MQTT_TOPIC}/{uri.lower()}/wifi", wifi),
         (f"{MQTT_TOPIC}/{uri.lower()}/audio", json.dumps(audio) if audio else False),
-        (f"{MQTT_TOPIC}/{uri.lower()}/ip", sess.camera.ip),
+        (f"{MQTT_TOPIC}/{uri.lower()}/ip", sess.camera.ip, 0, True),
     ]
     publish_messages(mqtt)
     return v_codec, audio

--- a/home_assistant/CHANGELOG.md
+++ b/home_assistant/CHANGELOG.md
@@ -1,3 +1,8 @@
+## What's Changed in v2.9.3
+
+- FIX: Clear the retain flag from MQTT Discovery which was causing commands to be resent to the bridge on startup for some users. (#1182)
+- Ignore commands when connection is stopping.
+
 ## What's Changed in v2.9.2
 
 - Improved video connection stability and audio sync.  #1175 #1196 #1194 #1193 #1186 Thanks @vipergts450!


### PR DESCRIPTION
## What's Changed in v2.9.3

- FIX: Clear the retain flag from MQTT Discovery which was causing commands to be resent to the bridge on startup for some users. (#1182)
- Ignore commands when connection is stopping.
