### PR TITLE
fix!: fix mixed case when URI_MAC=true

### DIFF
--- a/app/wyzecam/api_models.py
+++ b/app/wyzecam/api_models.py
@@ -146,9 +146,10 @@ class WyzeCamera(BaseModel):
         uri_sep = "-"
         if os.getenv("URI_SEPARATOR") in {"-", "_", "#"}:
             uri_sep = os.getenv("URI_SEPARATOR", uri_sep)
-        uri = clean_name(self.nickname or self.mac, uri_sep).lower()
+        uri = self.nickname or self.mac
         if os.getenv("URI_MAC", "").lower() == "true" and (self.mac or self.parent_mac):
             uri += uri_sep + (self.mac or self.parent_mac or "")[-4:]
+        uri = clean_name(uri, uri_sep).lower()
         return uri
 
     @property


### PR DESCRIPTION
When URI_MAC=true, value returned from function name_uri appends the  MAC suffix as uppercase to an otherwise lowercase camera name (e.g.,  backyard-camera-ABCD). This results in "duplicate" MQTT endpoints;  one with a lowercase and one with an uppercase MAC suffix, causing  MQTT commands to fail. This fixes changes the function so that the  return result will be entirely lowercase.

Resolves: mrlt8/docker-wyze-bridge#1382

BREAKING CHANGE: 

URI change to all lowercase for consistency with current conventions

Users whose config includes URI_MAC=true will need to update URIs