### PR TITLE
Add host_network: true for use in home assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# Recommend switching to idisposable fork as it is being updated: https://github.com/idisposable/docker-wyze-bridge .
+
+
 [![Docker](https://github.com/mrlt8/docker-wyze-bridge/actions/workflows/docker-image.yml/badge.svg)](https://github.com/mrlt8/docker-wyze-bridge/actions/workflows/docker-image.yml)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/mrlt8/docker-wyze-bridge?logo=github)](https://github.com/mrlt8/docker-wyze-bridge/releases/latest)
 [![Docker Image Size (latest semver)](https://img.shields.io/docker/image-size/mrlt8/wyze-bridge?sort=semver&logo=docker&logoColor=white)](https://hub.docker.com/r/mrlt8/wyze-bridge)

--- a/home_assistant/config.yml
+++ b/home_assistant/config.yml
@@ -13,6 +13,7 @@ startup: application
 boot: auto
 apparmor: false
 hassio_api: true
+host_network: true
 ports:
   1935/tcp: 1935
   8554/tcp: 8554

--- a/home_assistant/config.yml
+++ b/home_assistant/config.yml
@@ -3,7 +3,7 @@ description: WebRTC/RTSP/RTMP/LL-HLS bridge for Wyze cams in a docker container
 slug: docker_wyze_bridge
 url: https://github.com/mrlt8/docker-wyze-bridge
 image: mrlt8/wyze-bridge
-version: 2.10.3
+version: 3.0.6
 stage: stable
 arch:
   - armv7

--- a/home_assistant/config.yml
+++ b/home_assistant/config.yml
@@ -3,7 +3,7 @@ description: WebRTC/RTSP/RTMP/LL-HLS bridge for Wyze cams in a docker container
 slug: docker_wyze_bridge
 url: https://github.com/mrlt8/docker-wyze-bridge
 image: mrlt8/wyze-bridge
-version: 3.0.6
+version: 2.10.3
 stage: stable
 arch:
   - armv7

--- a/home_assistant/dev/config.yml
+++ b/home_assistant/dev/config.yml
@@ -12,6 +12,7 @@ startup: application
 boot: auto
 apparmor: false
 hassio_api: true
+host_network: true
 ports:
   1935/tcp: 1935
   8554/tcp: 8554

--- a/home_assistant/edge/config.yml
+++ b/home_assistant/edge/config.yml
@@ -12,6 +12,7 @@ startup: application
 boot: auto
 apparmor: false
 hassio_api: true
+host_network: true
 ports:
   1935/tcp: 1935
   8554/tcp: 8554

--- a/home_assistant/hw/config.yml
+++ b/home_assistant/hw/config.yml
@@ -10,6 +10,7 @@ startup: application
 boot: auto
 apparmor: false
 hassio_api: true
+host_network: true
 ports:
   1935/tcp: 1935
   8554/tcp: 8554

--- a/home_assistant/previous/config.yml
+++ b/home_assistant/previous/config.yml
@@ -13,6 +13,7 @@ startup: application
 boot: auto
 apparmor: false
 hassio_api: true
+host_network: true
 ports:
   1935/tcp: 1935
   8554/tcp: 8554


### PR DESCRIPTION
Docker changes something, so this addon must run on the host network for some cameras

Fixes: https://github.com/mrlt8/docker-wyze-bridge/issues/1438 https://github.com/mrlt8/docker-wyze-bridge/issues/1433 https://github.com/mrlt8/docker-wyze-bridge/issues/1434