### PR TITLE
Fix hardware accelerated rotation.

### DIFF
--- a/app/wyzebridge/ffmpeg.py
+++ b/app/wyzebridge/ffmpeg.py
@@ -61,7 +61,7 @@ def get_ffmpeg_cmd(
         ["-hide_banner", "-loglevel", get_log_level()]
         + env_cam("FFMPEG_FLAGS", uri, flags).strip("'\"\n ").split()
         + thread_queue.split()
-        + (["-hwaccel", h264_enc] if h264_enc in {"vaapi", "qsv"} else [])
+        + (["-hwaccel", h264_enc, "-hwaccel_output_format", h264_enc] if h264_enc in {"vaapi", "qsv"} else [])
         + ["-f", vcodec, "-i", "pipe:0"]
         + audio_in.split()
         + ["-map", "0:v", "-c:v"]
@@ -123,10 +123,11 @@ def re_encode_video(uri: str, is_vertical: bool) -> list[str]:
     v_filter = []
     transpose = "clock"
     if (env_bool("ROTATE_DOOR") and is_vertical) or env_bool(f"ROTATE_CAM_{uri}"):
-        if os.getenv(f"ROTATE_CAM_{uri}") in {"0", "1", "2", "3"}:
+        unchecked_transpose = env_cam("rotate_cam", uri)
+        if unchecked_transpose in {"0", "1", "2", "3"}:
             # Numerical values are deprecated, and should be dropped
             #  in favor of symbolic constants.
-            transpose = os.environ[f"ROTATE_CAM_{uri}"]
+            transpose = unchecked_transpose
 
         v_filter = ["-filter:v", f"transpose={transpose}"]
         if h264_enc == "h264_vaapi":


### PR DESCRIPTION
Also fix another bug where rotation was always set to 'clock' due to reading raw camera names instead of capitalizing them before accessing env variables.

I tested this on a vaapi-enabled machine but looking at the following snippet from `frigate` ffmpeg code, I'm confident that this change also fixes things for `qsv`:
https://github.com/blakeblackshear/frigate/blob/6f9d9cd5a853b7c7cb4058ada8dccdca8cbc3f5b/frigate/ffmpeg_presets.py#L67-L68

Closes #1276