### PR TITLE
Fix Wyze Cam V4 IOTC_ER_TIMEOUT with firmware 4.52.9.5332+

### DIFF
--- a/app/wyzebridge/wyze_stream.py
+++ b/app/wyzebridge/wyze_stream.py
@@ -447,6 +447,21 @@ def start_tutk_stream(uri: str, stream: StreamTuple, queue: QueueTuple, state: c
     except TutkError as ex:
         logger.warning(f"{[ex.code]} {ex}")
         set_cam_offline(uri, ex, was_offline)
+        if ex.code == -13 and stream.camera.product_model == "HL_CAM4":
+            fw = stream.camera.firmware_ver or "unknown"
+            logger.error(
+                f"[V4] IOTC_ER_TIMEOUT (-13) for {stream.camera.nickname} "
+                f"(FW: {fw}). V4 firmware 4.52.9.5332+ may require TUTK SDK "
+                f"4.3.x for full DTLS support. Recommended: downgrade V4 "
+                f"firmware to 4.52.9.4188 via Wyze app or SD card."
+            )
+        elif ex.code == -10:
+            logger.error(
+                f"IOTC_ER_UNLICENSE (-10) for "
+                f"{stream.camera.nickname}. This device may require "
+                f"a valid SDK_KEY. Set the SDK_KEY env var with a licensed "
+                f"TUTK SDK key."
+            )
         if ex.code in {-10, -13, -19, -68, -90}:
             exit_code = ex.code
     except ValueError as ex:

--- a/app/wyzecam/iotc.py
+++ b/app/wyzecam/iotc.py
@@ -694,8 +694,19 @@ class WyzeIOTCSession:
                 raise tutk.TutkError(session_id)
             self.session_id = session_id
 
-            if not self.camera.dtls and not self.camera.parent_dtls:
+            use_dtls = self.camera.dtls or self.camera.parent_dtls
+            # Force DTLS for V4 cameras — firmware 4.52.9.5332+ requires it
+            # even if the API reports dtls=0
+            if self.camera.product_model == "HL_CAM4" and not use_dtls:
+                logger.info(
+                    "[V4] Forcing DTLS auth for Cam V4 "
+                    "(required for firmware 4.52.9.5332+)"
+                )
+                use_dtls = True
+
+            if not use_dtls:
                 logger.debug("Connect via IOTC_Connect_ByUID_Parallel")
+                self.connect_timeout = int(os.getenv("LAN_TIMEOUT", 10))
                 session_id = tutk.iotc_connect_by_uid_parallel(
                     self.tutk_platform_lib, self.camera.p2p_id, self.session_id
                 )
@@ -704,15 +715,27 @@ class WyzeIOTCSession:
                 password = self.camera.enr
                 if self.camera.parent_dtls:
                     password = self.camera.parent_enr
+                p2p_timeout = int(os.getenv("P2P_TIMEOUT", 20))
+                self.connect_timeout = p2p_timeout
                 session_id = tutk.iotc_connect_by_uid_ex(
                     self.tutk_platform_lib,
                     self.camera.p2p_id,
                     self.session_id,
                     self.get_auth_key(),
-                    self.connect_timeout,
+                    p2p_timeout,
                 )
 
             if session_id < 0:  # type: ignore
+                if session_id == -13 and self.camera.product_model == "HL_CAM4":
+                    fw = self.camera.firmware_ver or "unknown"
+                    logger.error(
+                        f"[V4] IOTC_ER_TIMEOUT (-13) connecting to "
+                        f"{self.camera.nickname} (FW: {fw}). "
+                        f"V4 firmware 4.52.9.5332+ requires DTLS auth that "
+                        f"TUTK SDK 4.2.x may not fully support. "
+                        f"Recommended fix: downgrade V4 firmware to 4.52.9.4188 "
+                        f"via Wyze app or SD card."
+                    )
                 raise tutk.TutkError(session_id)
             self.session_id = session_id
 

--- a/app/wyzecam/tutk/tutk.py
+++ b/app/wyzecam/tutk/tutk.py
@@ -953,6 +953,7 @@ def iotc_connect_by_uid_ex(
     """
     connect_input = St_IOTCConnectInput()
     connect_input.cb = sizeof(connect_input)
+    connect_input.authentication_type = 1  # Force DTLS authentication
     connect_input.auth_key = auth_key.encode()
     connect_input.timeout = timeout
 


### PR DESCRIPTION
## Problem

Wyze Cam V4 (HL_CAM4) cameras running firmware **4.52.9.5332 or newer** fail to connect with `IOTC_ER_TIMEOUT (-13)`. The connection drops during the IOTC session setup phase with no useful error message.

## Root Cause

The newer V4 firmware enforces stricter DTLS authentication requirements. The TUTK SDK 4.2.1 used by docker-wyze-bridge does not automatically force DTLS/`auth_type=1` for all V4 cameras. When the Wyze API reports `dtls=0` for a V4 camera, the bridge uses the non-DTLS `IOTC_Connect_ByUID_Parallel` path, which the newer firmware rejects.

## What These Changes Fix

- **Force DTLS authentication for all V4 cameras** (`HL_CAM4`), even when the API reports `dtls=0`. This uses `IOTC_Connect_ByUIDEx` with the auth key, matching what the newer firmware expects.
- **Set `authentication_type=1`** in the `St_IOTCConnectInput` struct for DTLS connections, explicitly requesting DTLS auth mode in the TUTK SDK.
- **Add `LAN_TIMEOUT` and `P2P_TIMEOUT` environment variables** to allow users to tune connection timeouts (defaults: 10s LAN, 20s P2P).
- **Add actionable error messages** when V4 cameras hit `IOTC_ER_TIMEOUT`, pointing users to the firmware downgrade workaround.
- **Add `IOTC_ER_UNLICENSE` (-10) handling** with guidance to set the `SDK_KEY` env var.

## What These Changes Do NOT Fix

A **full fix** for all V4 firmware versions requires **TUTK SDK 4.3.x**, which includes native DTLS negotiation improvements for newer Wyze firmware. The TUTK SDK is proprietary and not yet available for this project. These changes are a best-effort workaround using SDK 4.2.1.

## Environment Variables Added

| Variable | Default | Description |
|---|---|---|
| `LAN_TIMEOUT` | `10` (seconds) | Timeout for non-DTLS LAN connections |
| `P2P_TIMEOUT` | `20` (seconds) | Timeout for DTLS/P2P connections |

## Recommended Workaround

If V4 cameras still fail after this patch, **downgrade the V4 firmware to 4.52.9.4188** using the Wyze app or SD card flashing. This is the last firmware version that works reliably with TUTK SDK 4.2.x.

## Files Changed

- `app/wyzecam/iotc.py` — Force DTLS path for HL_CAM4; add timeout env vars; add V4-specific error logging
- `app/wyzecam/tutk/tutk.py` — Set `authentication_type=1` in IOTC connect input struct
- `app/wyzebridge/wyze_stream.py` — Add targeted error messages for V4 timeout and IOTC_ER_UNLICENSE errors